### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/leaanthony/f2bb7ee3-e4eb-42b6-843d-fe8f30486689/607ebebf-3177-44e7-8251-d667c95d184e/_apis/work/boardbadge/30f18612-6aea-4323-90fa-3823a626fd89)](https://dev.azure.com/leaanthony/f2bb7ee3-e4eb-42b6-843d-fe8f30486689/_boards/board/t/607ebebf-3177-44e7-8251-d667c95d184e/Microsoft.RequirementCategory)
 ---
 home: true
 heroImage: /media/logo.png


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/leaanthony/f2bb7ee3-e4eb-42b6-843d-fe8f30486689/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.