### PR TITLE
docs: Mark Windows as Working

### DIFF
--- a/project_status.md
+++ b/project_status.md
@@ -45,7 +45,7 @@ The current status of template/Platform support is as follows:
 | ---------- | ------- | --------- | --------------- |
 | Vue Basic  | Working |  Working  |   Working       |
 | Vuetify    | Working |  Working  |   Working       |
-| React      | Working |  Working  |   [Not Working](https://github.com/wailsapp/wails/issues/145)   |
+| React      | Working |  Working  |   Working       |
 | Angular    | Working |  Working  |   [Not Working](https://github.com/wailsapp/wails/issues/146)   |
 
 


### PR DESCRIPTION
Windows is currently marked as Not Working, due to [#145](https://github.com/wailsapp/wails/issues/145) but this has recently been closed.

I have tested on Windows and it's building my Wails application perfectly.

![Screen Shot 2019-07-21 at 3 35 36 pm](https://user-images.githubusercontent.com/1100843/61587416-77ea4d00-abcd-11e9-9aa1-de102ae31c29.png)
